### PR TITLE
Remove docker container after running "composer install"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,8 +14,5 @@ trim_trailing_whitespace = false
 [*.{yml,yaml}]
 indent_size = 2
 
-[docker-compose.yml]
-indent_size = 4
-
 [composer.json]
 indent_size = 2

--- a/bin/dev
+++ b/bin/dev
@@ -5,7 +5,7 @@ set -eu
 cd $(dirname "$0")/../
 
 if [ ! -d vendor/ ] || [ ! -f vendor/bin/dev ]; then
-    docker-compose run -u $(id -u):$(id -g) --no-deps app composer install
+    docker compose run --rm -u $(id -u):$(id -g) --no-deps app composer install
 fi
 
 if [ -f vendor/bin/dev ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
- Remove docker container after "composer install" was completed
- Removed incorrect indent_size (2 spaces was used) setting
- Fixed warning: "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
- Use "docker compose" instead of the deprecated "docker-compose" command